### PR TITLE
Change of the run number metadata in storeMO

### DIFF
--- a/analysismacros/AnalyzeErrorsFHR.C
+++ b/analysismacros/AnalyzeErrorsFHR.C
@@ -220,7 +220,7 @@ if(ccdb_upload){
     string canvas_name("FHRErrorPlotSummary");
 
     canvas.SetName(canvas_name.c_str());
-        auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas, TaskName,TaskClass, DetectorName,1,Runperiod);
+        auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas, TaskName,TaskClass, DetectorName,std::stoi(runnumbers.front()),Runperiod);
         mo1->setIsOwner(false);
         ccdb->storeMO(mo1);
         }
@@ -262,7 +262,7 @@ if(ccdb_upload){
     string canvas_name2("FHRError_trends_IB");
 
     canvas2.SetName(canvas_name2.c_str());
-        auto mo2= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas2, TaskName,TaskClass, DetectorName,1,Runperiod);
+        auto mo2= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas2, TaskName,TaskClass, DetectorName,std::stoi(runnumbers.front()),Runperiod);
         mo2->setIsOwner(false);
         ccdb->storeMO(mo2);
         }
@@ -291,7 +291,7 @@ if(ccdb_upload){
     string canvas_name3("FHRError_trends_OB");
 
     canvas3.SetName(canvas_name3.c_str());
-        auto mo3= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas3, TaskName, TaskClass, DetectorName,1,Runperiod);
+        auto mo3= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas3, TaskName, TaskClass, DetectorName,std::stoi(runnumbers.front()),Runperiod);
         mo3->setIsOwner(false);
         ccdb->storeMO(mo3);
         }

--- a/analysismacros/AnalyzeLaneStatusFlag.C
+++ b/analysismacros/AnalyzeLaneStatusFlag.C
@@ -203,18 +203,19 @@ void DoAnalysis(string filepath, const int nChips, string skipruns, bool ccdb_up
 
 	if(ccdb_upload){
 	string Runperiod = Form("%s",filepath.substr(filepath.find("from"),27).c_str());
+	int RunNumber = std::stoi(filepath.substr(filepath.find("n")+1,6).c_str());
 	canvas.SetName("Summary_Lane_Status_Flag_ERROR");
-	auto mo_err= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas, TaskName, TaskClass, DetectorName,1,Runperiod);
+	auto mo_err= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas, TaskName, TaskClass, DetectorName,RunNumber,Runperiod);
 	mo_err->setIsOwner(false);
 	ccdb->storeMO(mo_err);
 
 	canvas12.SetName("Summary_Lane_Status_Flag_FAULT");
-        auto mo_fault= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas12, TaskName, TaskClass, DetectorName,1,Runperiod);
+        auto mo_fault= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas12, TaskName, TaskClass, DetectorName,RunNumber,Runperiod);
         mo_fault->setIsOwner(false);
         ccdb->storeMO(mo_fault);
 
         canvas13.SetName("Summary_Lane_Status_Flag_WARNING");
-        auto mo_warn= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas13, TaskName, TaskClass, DetectorName,1,Runperiod);
+        auto mo_warn= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas13, TaskName, TaskClass, DetectorName,RunNumber,Runperiod);
         mo_warn->setIsOwner(false);
         ccdb->storeMO(mo_warn);
 			}

--- a/analysismacros/AnalyzeLayerAverageClusterSize.C
+++ b/analysismacros/AnalyzeLayerAverageClusterSize.C
@@ -402,9 +402,10 @@ void DoAnalysis(string sFile_Path, string sSkip_Runs, int IBorOB, bool ccdb_uplo
          if(ccdb_upload){
             // The number 27 is the sum of the 2*6 digit run numbers+ len("_to_run")+len("from_run")
             string Runperiod = Form("%s",sFile_Path.substr(sFile_Path.find("from"), 27).c_str());
-            string canvas_name = Form("Layer%s_average_cluster_size", vLayerNumber[nRunsTot].c_str());
+            int RunNumber = std::stoi(sFile_Path.substr(sFile_Path.find("n")+1,6).c_str());
+	    string canvas_name = Form("Layer%s_average_cluster_size", vLayerNumber[nRunsTot].c_str());
             canvas->SetName(canvas_name.c_str());
-            auto mo1 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s", vLayerNumber[nRunsTot].c_str()), TaskClass, DetectorName, 1, Runperiod); // @ CCDB upload
+            auto mo1 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s", vLayerNumber[nRunsTot].c_str()), TaskClass, DetectorName, RunNumber, Runperiod); // @ CCDB upload
             mo1->setIsOwner(false);
             ccdb->storeMO(mo1);
          }
@@ -414,9 +415,10 @@ void DoAnalysis(string sFile_Path, string sSkip_Runs, int IBorOB, bool ccdb_uplo
          // The number 27 is the sum of the 2*6 digit run numbers+ len("_to_run")+len("from_run")
          if(ccdb_upload){
             string Runperiod = Form("%s",sFile_Path.substr(sFile_Path.find("from"),27).c_str());
-            string canvas_name2 = Form("Layer%s_average_cluster_size_HSLower", vLayerNumber[nRunsTot].c_str());
+        int RunNumber = std::stoi(sFile_Path.substr(sFile_Path.find("n")+1,6).c_str());  
+	  string canvas_name2 = Form("Layer%s_average_cluster_size_HSLower", vLayerNumber[nRunsTot].c_str());
             canvas->SetName(canvas_name2.c_str());
-            auto mo2 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s", vLayerNumber[nRunsTot].c_str()), TaskClass, DetectorName,1,Runperiod); // @ CCDB upload
+            auto mo2 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s", vLayerNumber[nRunsTot].c_str()), TaskClass, DetectorName,RunNumber,Runperiod); // @ CCDB upload
             mo2->setIsOwner(false);
             ccdb->storeMO(mo2);
          }
@@ -440,8 +442,9 @@ void DoAnalysis(string sFile_Path, string sSkip_Runs, int IBorOB, bool ccdb_uplo
 
             // The number 27 is the sum of the 2*6 digit run numbers+ len("_to_run")+len("from_run")
             string Runperiod = Form("%s",sFile_Path.substr(sFile_Path.find("from"), 27).c_str());
-            Secondcanvas->SetName(Secondcanvas_name.c_str());
-            auto mo3 = std::make_shared<o2::quality_control::core::MonitorObject>(Secondcanvas, TaskName+Form("/Layer%s", vLayerNumber[nRunsTot].c_str()), TaskClass, DetectorName, 1 , Runperiod); //  @ CCDB  upload
+       int RunNumber = std::stoi(sFile_Path.substr(sFile_Path.find("n")+1,6).c_str());
+	     Secondcanvas->SetName(Secondcanvas_name.c_str());
+            auto mo3 = std::make_shared<o2::quality_control::core::MonitorObject>(Secondcanvas, TaskName+Form("/Layer%s", vLayerNumber[nRunsTot].c_str()), TaskClass, DetectorName, RunNumber , Runperiod); //  @ CCDB  upload
             mo3->setIsOwner(false);
             ccdb->storeMO(mo3);
          }

--- a/analysismacros/AnalyzeLayerClusterOccupancy.C
+++ b/analysismacros/AnalyzeLayerClusterOccupancy.C
@@ -403,8 +403,9 @@ void DoAnalysis(string sFile_Path, string sSkip_Runs, int IBorOB, bool ccdb_uplo
             // The number 27 is the sum of the 2*6 digit run numbers+ len("_to_run")+len("from_run")
             string Runperiod = Form("%s",sFile_Path.substr(sFile_Path.find("from"), 27).c_str());
             string canvas_name = Form("Layer%s_cluster_occupation", vLayerNumber[nRunsTot].c_str());
-            canvas->SetName(canvas_name.c_str());
-            auto mo1 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s", vLayerNumber[nRunsTot].c_str()), TaskClass, DetectorName, 1, Runperiod); // @ CCDB upload
+            int RunNumber = std::stoi(sFile_Path.substr(sFile_Path.find("n")+1,6).c_str());
+	    canvas->SetName(canvas_name.c_str());
+            auto mo1 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s", vLayerNumber[nRunsTot].c_str()), TaskClass, DetectorName, RunNumber, Runperiod); // @ CCDB upload
             mo1->setIsOwner(false);
             ccdb->storeMO(mo1);
          }
@@ -415,8 +416,9 @@ void DoAnalysis(string sFile_Path, string sSkip_Runs, int IBorOB, bool ccdb_uplo
          if(ccdb_upload){
             string Runperiod = Form("%s",sFile_Path.substr(sFile_Path.find("from"),27).c_str());
             string canvas_name2 = Form("Layer%s_cluster_occupation_HSLower", vLayerNumber[nRunsTot].c_str());
+	   int RunNumber = std::stoi(sFile_Path.substr(sFile_Path.find("n")+1,6).c_str());
             canvas->SetName(canvas_name2.c_str());
-            auto mo2 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s", vLayerNumber[nRunsTot].c_str()), TaskClass, DetectorName,1,Runperiod); // @ CCDB upload
+            auto mo2 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s", vLayerNumber[nRunsTot].c_str()), TaskClass, DetectorName,RunNumber,Runperiod); // @ CCDB upload
             mo2->setIsOwner(false);
             ccdb->storeMO(mo2);
          }
@@ -441,7 +443,8 @@ void DoAnalysis(string sFile_Path, string sSkip_Runs, int IBorOB, bool ccdb_uplo
             // The number 27 is the sum of the 2*6 digit run numbers+ len("_to_run")+len("from_run")
             string Runperiod = Form("%s",sFile_Path.substr(sFile_Path.find("from"), 27).c_str());
             Secondcanvas->SetName(Secondcanvas_name.c_str());
-            auto mo3 = std::make_shared<o2::quality_control::core::MonitorObject>(Secondcanvas, TaskName+Form("/Layer%s", vLayerNumber[nRunsTot].c_str()), TaskClass, DetectorName, 1 , Runperiod); //  @ CCDB  upload
+       	int RunNumber = std::stoi(sFile_Path.substr(sFile_Path.find("n")+1,6).c_str());   
+	     auto mo3 = std::make_shared<o2::quality_control::core::MonitorObject>(Secondcanvas, TaskName+Form("/Layer%s", vLayerNumber[nRunsTot].c_str()), TaskClass, DetectorName, 1 , Runperiod); //  @ CCDB  upload
             mo3->setIsOwner(false);
             ccdb->storeMO(mo3);
          }

--- a/analysismacros/AnalyzeLayerDeadPixels.C
+++ b/analysismacros/AnalyzeLayerDeadPixels.C
@@ -179,7 +179,7 @@ itsAnalysis myAnalysis("DeadPixel");
 	string Runperiod = Form("from_run%s_to_run%s",runNumbers.back().c_str(),runNumbers[0].c_str());		
  //   string Runperiod = Form("%s",filepath.substr(filepath.find("from"),27).c_str()); //This should be used for actual data 
 	canvas->SetName(Form("Layer%s_Dead_pixels",layer.c_str()));
-	auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,1,Runperiod);
+	auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,std::stoi(runNumbers.back()),Runperiod);
         mo1->setIsOwner(false);
         ccdb->storeMO(mo1);
 }
@@ -214,7 +214,7 @@ if(ccdb_upload){
         string Runperiod = Form("from_run%s_to_run%s",runNumbers.back().c_str(),runNumbers[0].c_str());
 //   string Runperiod = Form("%s",filepath.substr(filepath.find("from"),27).c_str()); //This should be used for actual data 
         canvas->SetName(Form("Layer%s_HS_Upper_Dead_pixels",layer.c_str()));
-        auto mo2= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,1,Runperiod);
+        auto mo2= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,std::stoi(runNumbers.back()),Runperiod);
         mo2->setIsOwner(false);
         ccdb->storeMO(mo2);
 }
@@ -227,7 +227,7 @@ if(ccdb_upload){
         string Runperiod = Form("from_run%s_to_run%s",runNumbers.back().c_str(),runNumbers[0].c_str());  
 //   string Runperiod = Form("%s",filepath.substr(filepath.find("from"),27).c_str()); //This should be used for actual data 
         canvas->SetName(Form("Layer%s_HS_Lower_Dead_pixels",layer.c_str()));
-        auto mo3= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,1,Runperiod);
+        auto mo3= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,std::stoi(runNumbers.back()),Runperiod);
         mo3->setIsOwner(false);
         ccdb->storeMO(mo3);
 }

--- a/analysismacros/AnalyzeLayerOccupancy.C
+++ b/analysismacros/AnalyzeLayerOccupancy.C
@@ -391,7 +391,7 @@ if(ccdb_upload){
      string Runperiod = Form("%s",filepath.substr(filepath.find("from"),27).c_str());
      string canvas_name = Form("Layer%s_fakehitrate_w_error_and_trig_data", laynums[nRunsTot].c_str()); 
        canvas->SetName(canvas_name.c_str());
-        auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",laynums[nRunsTot].c_str()), TaskClass, DetectorName,1,Runperiod);
+        auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",laynums[nRunsTot].c_str()), TaskClass, DetectorName,std::stoi(runnumbers.front()),Runperiod);
         mo1->setIsOwner(false);
         ccdb->storeMO(mo1);}
 
@@ -405,7 +405,7 @@ if(ccdb_upload){
 	string Runperiod = Form("%s",filepath.substr(filepath.find("from"),27).c_str());
       string canvas_name2 = Form("Layer%s_fakehitrate_w_error_and_trig_data_HSLower",laynums[nRunsTot].c_str());
         canvas->SetName(canvas_name2.c_str());
-         auto mo2= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",laynums[nRunsTot].c_str()), TaskClass, DetectorName,1,Runperiod);
+         auto mo2= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",laynums[nRunsTot].c_str()), TaskClass, DetectorName,std::stoi(runnumbers.front()),Runperiod);
         mo2->setIsOwner(false);
         ccdb->storeMO(mo2);}
 
@@ -427,7 +427,7 @@ if(ccdb_upload){
   // The number 27 is the sum of the 2*6 digit run numbers+ len("_to_run")+len("from_run")
       string Runperiod = Form("%s",filepath.substr(filepath.find("from"),27).c_str());
       Secondcanvas->SetName(Secondcanvas_name.c_str());
-      auto mo3= std::make_shared<o2::quality_control::core::MonitorObject>(Secondcanvas, TaskName+Form("/Layer%s",laynums[nRunsTot].c_str()),TaskClass, DetectorName,1,Runperiod);
+      auto mo3= std::make_shared<o2::quality_control::core::MonitorObject>(Secondcanvas, TaskName+Form("/Layer%s",laynums[nRunsTot].c_str()),TaskClass, DetectorName,std::stoi(runnumbers.front()),Runperiod);
       mo3->setIsOwner(false);
       ccdb->storeMO(mo3);
 	}

--- a/analysismacros/AnalyzeLayerThresholds.C
+++ b/analysismacros/AnalyzeLayerThresholds.C
@@ -177,7 +177,7 @@ auto ccdb = dynamic_cast<CcdbDatabase*>(mydb.get());
  //   string Runperiod = Form("%s",filepath.substr(filepath.find("from"),27).c_str()); //This should be used for actual data	
      string canvas_name = Form("Layer%s_average_threshold", layer.c_str());
        canvas->SetName(canvas_name.c_str());
-        auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,1,Runperiod);
+        auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,std::stoi(runNumbers.back()),Runperiod);
         mo1->setIsOwner(false);
         ccdb->storeMO(mo1);}
       canvas->SaveAs(Form("../Plots/Layer%s_thresholds_run%s-run%s.pdf", layer.c_str(),runNumbers.back().c_str(),runNumbers[0].c_str()));
@@ -211,7 +211,7 @@ auto ccdb = dynamic_cast<CcdbDatabase*>(mydb.get());
  //   string Runperiod = Form("%s",filepath.substr(filepath.find("from"),27).c_str()); //This should be used for actual data    
        string canvas_name = Form("Layer%s_HS_Upper_average_threshold", layer.c_str());
        canvas->SetName(canvas_name.c_str());
-       auto mo2= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,1,Runperiod);
+       auto mo2= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,std::stoi(runNumbers.back()),Runperiod);
        mo2->setIsOwner(false);
        ccdb->storeMO(mo2);} 
 	 canvas->SaveAs(Form("../Plots/Layer%s_HS-upper_thresholds_run%s-run%s.pdf", layer.c_str(),runNumbers.back().c_str(),runNumbers[0].c_str()));
@@ -223,7 +223,7 @@ auto ccdb = dynamic_cast<CcdbDatabase*>(mydb.get());
      string Runperiod = Form("from_run%s_to_run%s",runNumbers.back().c_str(),runNumbers[0].c_str());
        string canvas_name = Form("Layer%s_HS_Lower_average_threshold", layer.c_str());
        canvas->SetName(canvas_name.c_str());
-       auto mo3= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,1,Runperiod);
+       auto mo3= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,std::stoi(runNumbers.back()),Runperiod);
        mo3->setIsOwner(false);
        ccdb->storeMO(mo3);}   
        canvas->SaveAs(Form("../Plots/Layer%s_HS-lower_thresholds_run%s-run%s.pdf", layer.c_str(),runNumbers.back().c_str(),runNumbers[0].c_str()));

--- a/analysismacros/AnalyzeTrgFlg.C
+++ b/analysismacros/AnalyzeTrgFlg.C
@@ -218,7 +218,7 @@ if(ccdb_upload){
     string canvas_name("FHRTrgFlgPlotSummary");
 
     canvas.SetName(canvas_name.c_str());
-        auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas, TaskName,TaskClass, DetectorName,1,Runperiod);
+        auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas, TaskName,TaskClass, DetectorName,std::stoi(runnumbers.front()),Runperiod);
         mo1->setIsOwner(false);
         ccdb->storeMO(mo1);
         }
@@ -259,7 +259,7 @@ if(ccdb_upload){
     string canvas_name2("FHRTrgFlags_trends_IB");
 
     canvas2.SetName(canvas_name2.c_str());
-        auto mo2= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas2, TaskName,TaskClass, DetectorName,1,Runperiod);
+        auto mo2= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas2, TaskName,TaskClass, DetectorName,std::stoi(runnumbers.front()),Runperiod);
         mo2->setIsOwner(false);
         ccdb->storeMO(mo2);
         }
@@ -288,7 +288,7 @@ if(ccdb_upload){
     string canvas_name3("FHRTrgFlags_trends_OB");
 
     canvas3.SetName(canvas_name3.c_str());
-        auto mo3= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas3, TaskName, TaskClass, DetectorName,1,Runperiod);
+        auto mo3= std::make_shared<o2::quality_control::core::MonitorObject>(&canvas3, TaskName, TaskClass, DetectorName,std::stoi(runnumbers.front()),Runperiod);
         mo3->setIsOwner(false);
         ccdb->storeMO(mo3);
         }

--- a/analysismacros/CompareDeadPixelsInRuns.C
+++ b/analysismacros/CompareDeadPixelsInRuns.C
@@ -229,7 +229,7 @@ if(ccdb_upload){
      string Runperiod = Form("from_run%s_to_run%s",runNumbers[0].c_str(),runNumbers[nRuns-1].c_str());
 //   string Runperiod = Form("%s",filepath.substr(filepath.find("from"),27).c_str()); //This should be used for actual data 
     canvas->SetName(Form("Layer%s_Dead_pixels_Correlation",layer.c_str()));
-    auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,1,Runperiod);
+    auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,std::stoi(runNumbers.back()),Runperiod);
     mo1->addMetadata("ReferenceRunNumber",refrun.c_str());
     mo1->setIsOwner(false);
     ccdb->storeMO(mo1);

--- a/analysismacros/CompareLayerOccupancy.C
+++ b/analysismacros/CompareLayerOccupancy.C
@@ -322,7 +322,7 @@ if(ccdb_upload){
     string Reference_run = to_string(refrun);
 
     canvas->SetName(canvas_name.c_str());
-        auto mo= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",laynums[nRunsTot].c_str()),TaskClass, DetectorName,1,Runperiod);
+        auto mo= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%s",laynums[nRunsTot].c_str()),TaskClass, DetectorName,std::stoi(runnumbers.front()),Runperiod);
         mo->addMetadata("ReferenceRunNumber",Reference_run.c_str());
 	mo->setIsOwner(false);
         ccdb->storeMO(mo);

--- a/analysismacros/CompareLayerThresholds.C
+++ b/analysismacros/CompareLayerThresholds.C
@@ -93,7 +93,7 @@ auto ccdb = dynamic_cast<CcdbDatabase*>(mydb.get());
 	string Runperiod = Form("from_run%s_to_run%s",runNumbers[0].c_str(),runNumbers[nRuns-1].c_str());
  //   string Runperiod = Form("%s",filepath.substr(filepath.find("from"),27).c_str()); //This should be used for actual data      
 	canvas->SetName(Form("Layer%s_Threshold_correlation",layer.c_str()));			
-	auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(canvas,TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,1,Runperiod);
+	auto mo1= std::make_shared<o2::quality_control::core::MonitorObject>(canvas,TaskName+Form("/Layer%s",layer.c_str()), TaskClass, DetectorName,std::stoi(runNumbers.back()),Runperiod);
  	mo1->addMetadata("ReferenceRunNumber",refrun.c_str());
         mo1->setIsOwner(false);
         ccdb->storeMO(mo1);

--- a/analysismacros/CompareNoisyPixelsInRuns.C
+++ b/analysismacros/CompareNoisyPixelsInRuns.C
@@ -493,7 +493,7 @@ void DoAnalysis(string filepath, const int nChips, string skipruns, long int ref
     if(ccdb_upload){
       string canvas_name = Form("Layer%d_NoisyPixComparison_Allstaves",ilay);
       canvas->SetName(canvas_name.c_str());
-      auto mo= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%d",ilay),TaskClass, DetectorName,1,Runperiod);
+      auto mo= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%d",ilay),TaskClass, DetectorName,std::stoi(runnumbers.front()),Runperiod);
       mo->addMetadata("ReferenceRunNumber",Reference_run.c_str());
       mo->setIsOwner(false);
       ccdb->storeMO(mo);	
@@ -553,7 +553,7 @@ void DoAnalysis(string filepath, const int nChips, string skipruns, long int ref
       
       if(ccdb_upload){
 	canvas->SetName(Form("Layer%d-Stave%d_NoisyPixComparison",ilay,is));
-	auto mo2= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%d",ilay),TaskClass, DetectorName,1,Runperiod);
+	auto mo2= std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%d",ilay),TaskClass, DetectorName,std::stoi(runnumbers.front()),Runperiod);
         mo2->addMetadata("ReferenceRunNumber",Reference_run.c_str());
         mo2->setIsOwner(false);
         ccdb->storeMO(mo2);

--- a/analysismacros/MakeDeadPixelMap.C
+++ b/analysismacros/MakeDeadPixelMap.C
@@ -121,7 +121,7 @@ auto ccdb = dynamic_cast<CcdbDatabase*>(mydb.get());
 	hHotMap->GetXaxis()->SetLabelOffset(0.003);
 	hHotMap->SetTitleSize(0.05);		
 	hHotMap->GetYaxis()->SetLabelSize(0.11);
-	auto mo = std::make_shared<o2::quality_control::core::MonitorObject>(hHotMap, TaskName+Form("/Layer%d",ilay), TaskClass, DetectorName,1,Runperiod);
+	auto mo = std::make_shared<o2::quality_control::core::MonitorObject>(hHotMap, TaskName+Form("/Layer%d",ilay), TaskClass, DetectorName,std::stoi(runNumbers.back()),Runperiod);
        mo->setIsOwner(false);
        ccdb->storeMO(mo);
 		}

--- a/analysismacros/MaskNoisyPixelsInRuns.C
+++ b/analysismacros/MaskNoisyPixelsInRuns.C
@@ -533,11 +533,12 @@ void DoAnalysis(string filepath_hit, string skipruns, int IBorOB, bool isOnlyHot
 	TString NameCnv = "";
 	// The number 27 is the sum of the 2*6 digit run numbers+ len("_to_run")+len("from_run")
 	string Runperiod = Form("%s",filepath_hit.substr(filepath_hit.find("from"),27).c_str());
+	int RunNumber = std::stoi(filepath_hit.substr(filepath_hit.find("n")+1,6).c_str());
 	if (StavePart==0){
 	  if (numStavePart==1){ NameCnv = Form("../Plots/Layer%i_FHRpixmask_%s", ilayEff,filepath_hit.substr(filepath_hit.find("from"), filepath_hit.find(".root")-filepath_hit.find("from")).c_str());
 	    if(ccdb_upload){
 	      canvas->SetName(Form("Layer%i_FHRpixmask",ilayEff));
-	      auto mo1 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%i",ilayEff),TaskClass, DetectorName,1,Runperiod);
+	      auto mo1 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%i",ilayEff),TaskClass, DetectorName,RunNumber,Runperiod);
 	      mo1->setIsOwner(false);
 	      ccdb->storeMO(mo1);
 	    }
@@ -545,7 +546,7 @@ void DoAnalysis(string filepath_hit, string skipruns, int IBorOB, bool isOnlyHot
 	  else {NameCnv = Form("../Plots/Layer%i_HSLower_FHRpixmask_%s", ilayEff, filepath_hit.substr(filepath_hit.find("from"), filepath_hit.find(".root")-filepath_hit.find("from")).c_str());
 	    if(ccdb_upload){
 	      canvas->SetName(Form("Layer%i_HSLower_FHRpixmask",ilayEff));
-	      auto mo2 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%i",ilayEff),TaskClass, DetectorName,1,Runperiod);
+	      auto mo2 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%i",ilayEff),TaskClass, DetectorName,RunNumber,Runperiod);
 	      mo2->setIsOwner(false);
 	      ccdb->storeMO(mo2);}
 	  }
@@ -553,7 +554,7 @@ void DoAnalysis(string filepath_hit, string skipruns, int IBorOB, bool isOnlyHot
 	else{ NameCnv = Form("../Plots/Layer%i_HSUpper_FHRpixmask_%s", ilayEff, filepath_hit.substr(filepath_hit.find("from"), filepath_hit.find(".root")-filepath_hit.find("from")).c_str());
 	  if(ccdb_upload){
 	    canvas->SetName(Form("Layer%i_HSUpper_FHRpixmask",ilayEff));
-	    auto mo3 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%i",ilayEff),TaskClass, DetectorName,1,Runperiod);
+	    auto mo3 = std::make_shared<o2::quality_control::core::MonitorObject>(canvas, TaskName+Form("/Layer%i",ilayEff),TaskClass, DetectorName,RunNumber,Runperiod);
 	    mo3->setIsOwner(false);
 	    ccdb->storeMO(mo3);
 	  }
@@ -634,7 +635,7 @@ void DoAnalysis(string filepath_hit, string skipruns, int IBorOB, bool isOnlyHot
         hHotMap[ilay][istave]->SetTitle(Form("Hitmap of Layer %d Stave %d",ilay,istave));
     	  hHotMap[ilay][istave]->SetTitleSize(0.05);
     	  hHotMap[ilay][istave]->GetYaxis()->SetLabelSize(0.11);
-    	  auto mohp= std::make_shared<o2::quality_control::core::MonitorObject>(hHotMap[ilay][istave], TaskName+Form("/Layer%d",ilay),TaskClass, DetectorName,1,Runperiod);
+    	  auto mohp= std::make_shared<o2::quality_control::core::MonitorObject>(hHotMap[ilay][istave], TaskName+Form("/Layer%d",ilay),TaskClass, DetectorName,RunNumber,Runperiod);
     	  mohp->setIsOwner(false);
     	  ccdb->storeMO(mohp);
 


### PR DESCRIPTION
Propagated the change of the run number in the metadata of the monitor objects that are stored in ccdb.It now reflects the first run number of the run period.